### PR TITLE
chore(deps): bump vuepress from 2.0.0-rc.8 to 2.0.0-rc.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "homepage": "https://wwebjs.dev",
   "license": "MIT",
   "devDependencies": {
-    "@vuepress/bundler-vite": "^2.0.0-rc.8",
-    "@vuepress/plugin-search": "^2.0.0-beta.67",
-    "@vuepress/theme-default": "^2.0.0-rc.18",
-    "vuepress": "^2.0.0-rc.8"
+    "@vuepress/bundler-vite": "2.0.0-rc.9",
+    "@vuepress/plugin-search": "^2.0.0-rc.24",
+    "@vuepress/theme-default": "2.0.0-rc.25",
+    "vuepress": "2.0.0-rc.9"
   }
 }


### PR DESCRIPTION
Bumps vuepress from 2.0.0-rc.8 to 2.0.0-rc.9
Bumps @vuepress/bundler-vite from 2.0.0-rc.8 to 2.0.0-rc.9 
Bumps @vuepress/plugin-search from 2.0.0-beta.67 to 2.0.0-rc.24 
Bumps @@vuepress/theme-default from 2.0.0-rc.18 to 2.0.0-rc.25