### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,11 @@
+name: 🐛 Bug Report
+description: Use this template to report a bug in the guide
+labels: [bug, documentation]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        **CLEARY DESCRIBE A BUG IN THE GUIDE YOU ARE REPORTING, YOU CAN ADD PICTURES IF YOU WANT TO:**
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Official WWebJS Discord Server
+    url: https://discord.gg/H7DqQs4
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/guide-additions.yml
+++ b/.github/ISSUE_TEMPLATE/guide-additions.yml
@@ -1,0 +1,11 @@
+name: 📚 Guide Additions Request
+description: Use this template to suggest additions for the guide
+labels: [documentation, enhancement]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        **CLEARY DESCRIBE GUIDE ADDITIONS YOU ARE REQUESTING, YOU CAN ADD PICTURES IF YOU WANT TO:**
+    validations:
+      required: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 package-lock.json
 .cache/
 .temp/
+.idea
+.vscode


### PR DESCRIPTION
### The PR adds issue templates for:
- Bug/typo report in the guide
- Guide additions request
- Config for the template chooser

### This is how it will look like for users:
- Being on the ***Issues*** tab:
![](https://github.com/wwebjs/wwebjs.dev/assets/93551621/b588f62c-b00e-4f99-a002-97d679399f4f)

---

- Being inside ***🐛 Bug Report***:
![](https://github.com/wwebjs/wwebjs.dev/assets/93551621/b062f627-1c91-4930-8ea3-326eb3b668a3)

---

- Being inside ***📚 Guide Additions Request***:
![](https://github.com/wwebjs/wwebjs.dev/assets/93551621/112e47a4-2d91-4517-b87c-46e541e6d876)


Also `.idea` and `.vscode` folders were added to `.gitignore`