### PR TITLE
fix: learn "basic javascript" link

### DIFF
--- a/src/guide/README.md
+++ b/src/guide/README.md
@@ -26,7 +26,7 @@ Getting into bot development with whatsapp-web.js is thrilling, but there are ce
 
 If you are a complete beginner, please take your time to learn more about the basics and come back with a better understanding of JavaScript and Node.js. Here are some free educational resources:
 
-- [JavaScript Basics](https://www.udacity.com/course/javascript-basics--ud804)
+- [JavaScript Basics](https://www.udacity.com/course/intro-to-javascript--cd2073)
 - [Modern JavaScript tutorials and examples](https://javascript.info/)
 - [Codecademy with it's interactive JavaScript course](https://www.codecademy.com/learn/introduction-to-javascript)
 - [NodeSchool learns you JavaScirpt and Node.js](https://nodeschool.io/)


### PR DESCRIPTION
### Description
Clicking on the "JavaScript Basic" link in the `/guide` page currently leads to a `404 not found` page.

#### Screenshot
![Screenshot 2024-10-05 165435](https://github.com/user-attachments/assets/a8fbe4ea-379b-4351-8143-ff0e4a287e0c)

### Fix
I updated the link to point to the correct JavaScript tutorial page 👍.